### PR TITLE
Retrieve other user calendar items

### DIFF
--- a/lib/EWS/Calendar/Role/RetrieveWithinWindow.pm
+++ b/lib/EWS/Calendar/Role/RetrieveWithinWindow.pm
@@ -61,6 +61,11 @@ sub retrieve_within_window {
                 {
                     DistinguishedFolderId => {
                         Id => "calendar",
+                        (exists $opts->{email} ? (
+                            Mailbox => {
+                                EmailAddress => $opts->{email},
+                            },
+                        ) : ()), # optional
                     },
                 },
             ],


### PR DESCRIPTION
It is possible to retrieve a users calendar items even when we don't
have permission to impersonate them. This adds an option for that
ability.
